### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   ],
   "need_gpu": false,
   "community_agent": true,
-  "docker_image": "supervisely/base-py-sdk:6.73.93",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "entrypoint": "python src/main.py",
   "port": 8000,
   "headless": true,

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
   ],
   "need_gpu": false,
   "community_agent": true,
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "entrypoint": "python src/main.py",
   "port": 8000,
   "headless": true,

--- a/config.json
+++ b/config.json
@@ -29,5 +29,5 @@
     "sliderValue": 5,
     "noBatches": false
   },
-  "min_instance_version": "6.9.22"
+  "instance_version": "6.15.60"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
